### PR TITLE
Use Apples CryptoKit when available & fall back to CommonCrypto

### DIFF
--- a/Sources/TelemetryClient/CryptoHashing.swift
+++ b/Sources/TelemetryClient/CryptoHashing.swift
@@ -1,0 +1,58 @@
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+import CommonCrypto
+import Foundation
+
+/// A wrapper for crypto hash algorithms.
+enum CryptoHashing {
+    /// Returns a String representation of the SHA256 digest created with Apples CryptoKit library if available, else falls back to the ``commonCryptoSha256(strData:)`` function.
+    /// [CryptoKit](https://developer.apple.com/documentation/cryptokit) is Apples modern, safe & performant crypto library that should be preferred where available.
+    /// [CommonCrypto](https://github.com/apple-oss-distributions/CommonCrypto) provides compatibility with older OS versions, apps built with Xcode versions lower than 11 and non-Apple platforms like Linux.
+    static func sha256(str: String) -> String {
+        if let strData = str.data(using: String.Encoding.utf8) {
+            #if canImport(CryptoKit)
+                if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
+                    let digest = SHA256.hash(data: strData)
+                    return digest.compactMap { String(format: "%02x", $0) }.joined()
+                } else {
+                    // OS version requirement not met, but built with Xcode 11+ for Apple Platforms
+                    return commonCryptoSha256(strData: strData)
+                }
+            #else
+                // Linux, etc. (and iOS when compiled with < Xcode 11.)
+                return commonCryptoSha256(strData: strData)
+            #endif
+        }
+        return ""
+    }
+
+    /**
+     * Example SHA 256 Hash using CommonCrypto
+     * CC_SHA256 API exposed from from CommonCrypto-60118.50.1:
+     * https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.50.1/include/CommonDigest.h.auto.html
+     **/
+    static func commonCryptoSha256(strData: Data) -> String {
+        /// #define CC_SHA256_DIGEST_LENGTH     32
+        /// Creates an array of unsigned 8 bit integers that contains 32 zeros
+        var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+
+        /// CC_SHA256 performs digest calculation and places the result in the caller-supplied buffer for digest (md)
+        /// Takes the strData referenced value (const unsigned char *d) and hashes it into a reference to the digest parameter.
+        _ = strData.withUnsafeBytes {
+            // CommonCrypto
+            // extern unsigned char *CC_SHA256(const void *data, CC_LONG len, unsigned char *md)  -|
+            // OpenSSL                                                                             |
+            // unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md)        <-|
+            CC_SHA256($0.baseAddress, UInt32(strData.count), &digest)
+        }
+
+        var sha256String = ""
+        /// Unpack each byte in the digest array and add them to the sha256String
+        for byte in digest {
+            sha256String += String(format: "%02x", UInt8(byte))
+        }
+
+        return sha256String
+    }
+}

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -1,4 +1,3 @@
-import CommonCrypto
 import Foundation
 
 #if os(iOS)
@@ -73,7 +72,7 @@ internal class SignalManager {
             let signalPostBody = SignalPostBody(
                 receivedAt: Date(),
                 appID: UUID(uuidString: configuration.telemetryAppID)!,
-                clientUser: sha256(str: clientUser ?? defaultUserIdentifier),
+                clientUser: CryptoHashing.sha256(str: clientUser ?? defaultUserIdentifier),
                 sessionID: configuration.sessionID.uuidString,
                 type: "\(signalType)",
                 payload: payLoad.toMultiValueDimension(),
@@ -226,38 +225,6 @@ private extension SignalManager {
         #endif
         return "unknown user \(SignalPayload.platform) \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
         #endif
-    }
-    
-    /**
-     * Example SHA 256 Hash using CommonCrypto
-     * CC_SHA256 API exposed from from CommonCrypto-60118.50.1:
-     * https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.50.1/include/CommonDigest.h.auto.html
-     **/
-    func sha256(str: String) -> String {
-        if let strData = str.data(using: String.Encoding.utf8) {
-            /// #define CC_SHA256_DIGEST_LENGTH     32
-            /// Creates an array of unsigned 8 bit integers that contains 32 zeros
-            var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-
-            /// CC_SHA256 performs digest calculation and places the result in the caller-supplied buffer for digest (md)
-            /// Takes the strData referenced value (const unsigned char *d) and hashes it into a reference to the digest parameter.
-            _ = strData.withUnsafeBytes {
-                // CommonCrypto
-                // extern unsigned char *CC_SHA256(const void *data, CC_LONG len, unsigned char *md)  -|
-                // OpenSSL                                                                             |
-                // unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md)        <-|
-                CC_SHA256($0.baseAddress, UInt32(strData.count), &digest)
-            }
-
-            var sha256String = ""
-            /// Unpack each byte in the digest array and add them to the sha256String
-            for byte in digest {
-                sha256String += String(format: "%02x", UInt8(byte))
-            }
-
-            return sha256String
-        }
-        return ""
     }
 }
 

--- a/Tests/TelemetryClientTests/CryptoHashingTests.swift
+++ b/Tests/TelemetryClientTests/CryptoHashingTests.swift
@@ -1,0 +1,23 @@
+@testable import TelemetryClient
+import XCTest
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+final class CryptoHashingTests: XCTestCase {
+   #if canImport(CryptoKit)
+   func testCryptoKitAndCommonCryptoHaveSameDigestStringResults() {
+      let stringToHash = "I ... can't be a wizard. I'm just Harry – just Harry!"
+      let dataToHash = stringToHash.data(using: .utf8)!
+
+      let expectedDigestString = "a83adf48122e22cf86cd139b846a5b3fa486982d3bb13413a6f46efa078edfa5"
+
+      XCTAssertEqual(expectedDigestString, CryptoHashing.sha256(str: stringToHash))
+      XCTAssertEqual(expectedDigestString, CryptoHashing.commonCryptoSha256(strData: dataToHash))
+
+      // calling directly to prove that CryptoKit produces same reult, as ``sha256(str:)`` can fall back,
+      // even if it shouldn't fallback here because we're inside a `canImport(CryptoKit)` check
+      XCTAssertEqual(expectedDigestString, SHA256.hash(data: dataToHash).compactMap { String(format: "%02x", $0) }.joined())
+   }
+   #endif
+}


### PR DESCRIPTION
This makes sure that Apple devices use Apples newer CryptoKit library for generating a SHA256 hash for improved safety & performance.

Note that there was a need for double-checking with both `#if canImport(CryptoKit)` and `if #available` to ensure full compatibility with all platforms & devices. See also [here](https://forums.swift.org/t/conditionally-use-cryptokit/30138/3).