### PR TITLE
Use a self-generated UUID as default ID on macOS + add tvOS support

### DIFF
--- a/Sources/TelemetryClient/CryptoHashing.swift
+++ b/Sources/TelemetryClient/CryptoHashing.swift
@@ -22,18 +22,16 @@ enum CryptoHashing {
                     return commonCryptoSha256(strData: strData)
                 }
             #else
-                // Linux, etc. (and iOS when compiled with < Xcode 11.)
+                // Linux, etc. (and iOS when compiled with < Xcode 11)
                 return commonCryptoSha256(strData: strData)
             #endif
         }
         return ""
     }
 
-    /**
-     * Example SHA 256 Hash using CommonCrypto
-     * CC_SHA256 API exposed from from CommonCrypto-60118.50.1:
-     * https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.50.1/include/CommonDigest.h.auto.html
-     **/
+    /// Example SHA 256 Hash using CommonCrypto
+    /// CC_SHA256 API exposed from from CommonCrypto-60118.50.1:
+    /// https://opensource.apple.com/source/CommonCrypto/CommonCrypto-60118.50.1/include/CommonDigest.h.auto.html
     static func commonCryptoSha256(strData: Data) -> String {
         /// #define CC_SHA256_DIGEST_LENGTH     32
         /// Creates an array of unsigned 8 bit integers that contains 32 zeros

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -208,7 +208,7 @@ private extension SignalManager {
     /// A custom ``UserDefaults`` instance specific to TelemetryDeck and the current application.
     private var customDefaults: UserDefaults? {
         let appIdHash = CryptoHashing.sha256(str: self.configuration.telemetryAppID, salt: "")
-        return UserDefaults(suiteName: "\(appIdHash).TelemetryDeck")
+        return UserDefaults(suiteName: "com.telemetrydeck.\(appIdHash.suffix(12))")
     }
     #endif
 


### PR DESCRIPTION
Note that I skipped the app group based API (outlined [here](https://github.com/TelemetryDeck/SwiftClient/issues/12#issuecomment-1185511462)) as I figured very few would actually need it and those could simply override the default ID and store it in their shared app group defaults.

Also, I noticed lack of support for tvOS which supports identifierForVendor just like iOS according to Apples docs, so I added it. Plus some really minor docs improvements.

Lastly, because there was a lot of `#else` end even a nested `#if` I opted to indent them here inside the `defaultUserIdentifier` implementation. I did not search for other places and make them consistent everywhere, so if you dislike this inconsistency, feel free to re-indent. If you dislike indented `#if` in general, a compromise could be to only allow/require indentation where the `#if` is made within a function body or when there's nesting involved.

Fixes https://github.com/TelemetryDeck/SwiftClient/issues/12.