### PR TITLE
Add tag-release.sh script for bumping version & tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,5 @@ let configuration = TelemetryManagerConfiguration(appID: "<YOUR-APP-ID>", baseUR
 ## Developing this SDK
 
 Your PRs on TelemetryDeck's Swift Client are very much welcome. Check out the [SwiftClientTester](https://github.com/TelemetryDeck/SwiftClientTester) project, which provides a harness you can use to work on the library and try out new things.
+
+When making a new release, run `./tag-release.sh MAJOR.MINOR.PATCH` to bump the version string in the SDK, create a new commit and tag that commit accordingly all in one step.

--- a/tag-release.sh
+++ b/tag-release.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# Invoke this script via: ./tag-release.sh MAJOR.MINOR.PATCH
+
+# Validate that there are no changes in Git prior making a release commit
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "ERROR! There are uncommitted changes, can't tag a release without a clean state.";
+  exit 1
+fi
+
+version=$1
+
+# Replace version String in TelemetryClient.swift with specified version
+sed -i '' "s/\"SwiftClient .*\"/\"SwiftClient $version\"/g" Sources/TelemetryClient/TelemetryClient.swift
+
+# Make a commit & tag it
+git add Sources/TelemetryClient/TelemetryClient.swift
+git commit -m "Bump Version to $version"
+git tag $version $(git rev-parse HEAD)
+
+echo "Successfully created a bump commit & tagged it with '$version'."
+echo "After checking everything, push the commit including the new tag!"


### PR DESCRIPTION
I put all in a shell script so you could invoke it from anywhere if you decide to further automate things (locally or on the CI).

The script takes the new version as an argument and does 4 things:
1. Check that there are no uncommitted changes (otherwise fails).
2. Replace the version String in the SDK.
3. Commit the changes.
4. Tag the new commit.

I decided against a lint check because such a check would require the tag to be already available but you created the latest tag _after_ merging https://github.com/TelemetryDeck/SwiftClient/pull/70, so a lint check would run when it's already too late. The same problem exists with pre-commit hooks, as a tag can only be created _after_ the commit is made.

Fixes #57.