### PR TITLE
Implement `analyticsDisabled` to allow an opt out of analytics

### DIFF
--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -10,7 +10,11 @@ import WatchKit
 import TVUIKit
 #endif
 
-internal class SignalManager {
+internal protocol SignalManageable {
+    func processSignal(_ signalType: TelemetrySignalType, for clientUser: String?, with additionalPayload: [String: String], configuration: TelemetryManagerConfiguration)
+}
+
+internal class SignalManager: SignalManageable {
     private let minimumWaitTimeBetweenRequests: Double = 10 // seconds
 
     private var signalCache: SignalCache<SignalPostBody>

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -53,4 +53,71 @@ final class TelemetryClientTests: XCTestCase {
         
         XCTAssertEqual(signals, allPoppedSignals)
     }
+    
+    func testSendsSignals_withAnalyticsImplicitlyEnabled() {
+        let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
+
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        
+        let signalManager = FakeSignalManager()
+        TelemetryManager.initialize(with: configuration, signalManager: signalManager)
+        
+        TelemetryManager.send("appOpenedRegularly")
+        
+        XCTAssertEqual(signalManager.processedSignals.count, 1)
+    }
+    
+    func testSendsSignals_withAnalyticsExplicitlyEnabled() {
+        let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
+
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        configuration.analyticsDisabled = false
+        
+        let signalManager = FakeSignalManager()
+        TelemetryManager.initialize(with: configuration, signalManager: signalManager)
+        
+        TelemetryManager.send("appOpenedRegularly")
+        
+        XCTAssertEqual(signalManager.processedSignals.count, 1)
+    }
+    
+    func testDoesNotSendSignals_withAnalyticsExplicitlyDisabled() {
+        let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
+
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        configuration.analyticsDisabled = true
+        
+        let signalManager = FakeSignalManager()
+        TelemetryManager.initialize(with: configuration, signalManager: signalManager)
+        
+        TelemetryManager.send("appOpenedRegularly")
+        
+        XCTAssertTrue(signalManager.processedSignals.isEmpty)
+    }
+    
+    func testDoesNotSendSignals_withAnalyticsExplicitlyEnabled_inPreviewMode() {
+        setenv("XCODE_RUNNING_FOR_PREVIEWS", "1", 1)
+
+        let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
+
+        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        configuration.analyticsDisabled = false
+        
+        let signalManager = FakeSignalManager()
+        TelemetryManager.initialize(with: configuration, signalManager: signalManager)
+        
+        TelemetryManager.send("appOpenedRegularly")
+        
+        XCTAssertTrue(signalManager.processedSignals.isEmpty)
+        
+        setenv("XCODE_RUNNING_FOR_PREVIEWS", "0", 1)
+    }
+}
+
+private class FakeSignalManager: SignalManageable {
+    var processedSignals = [TelemetrySignalType]()
+    
+    func processSignal(_ signalType: TelemetrySignalType, for clientUser: String?, with additionalPayload: [String : String], configuration: TelemetryManagerConfiguration) {
+        processedSignals.append(signalType)
+    }
 }


### PR DESCRIPTION
## Rationale

Provides a way to opt out of analytics by settings the value of `analyticsDisabled` to `true` on the configuration.

## Considerations

I've considered just re-using the `swiftUIPreviewMode` and setting it to `true` whenever I want to opt out of sending signals, however as I'm storing the opt-out state in the App's user defaults, if I'm using this value during development it might emit events signals in SwiftUIPreviews as well. To not interfere with this preference I've create the above mentioned property.

## Final words

Given this Pr is of interested and this feature will be implemented, I'm happy to also implement this in the Kotlin and JS SDKs.