### PR TITLE
Add a podspec for integration using Cocoapods.

### DIFF
--- a/TelemetryClient.podspec
+++ b/TelemetryClient.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |spec|
+  spec.name         = "TelemetryClient"
+  spec.version      = "1.4.2"
+  spec.summary      = "Client SDK for TelemetryDeck"
+  spec.swift_versions = "5.2"
+  spec.description  = "This package allows you to send signals to TelemetryDeck from your Swift code. Sign up for a free account at telemetrydeck.com."
+  spec.homepage     = "https://github.com/TelemetryDeck/SwiftClient"
+  spec.license      = { :type => "MIT", :file => "LICENSE" }
+  spec.author             = { "Daniel Jilg" => "daniel@telemetrydeck.com" }
+  spec.ios.deployment_target = "12.0"
+  spec.osx.deployment_target = "10.13"
+  spec.watchos.deployment_target = "5.0"
+  spec.tvos.deployment_target = "13.0"
+  spec.source       = { :git => "https://github.com/TelemetryDeck/SwiftClient.git", :tag => "#{spec.version}" }
+  spec.source_files  = "Sources/**/*.{h,m,swift}"
+end


### PR DESCRIPTION
One hiccup -- it looks like the podspec is failing linting right now, because it looks like Cocoapods has a bug where linting of watchOS doesn't work: https://github.com/CocoaPods/CocoaPods/issues/11558

So, either (1) you could remove watchOS from the spec until this is fixed, or (2) when you push it to trunk, you could push it with the `--skip-import-validation` option (i.e., `pod trunk push --skip-import-validation TelemetryClient.podspec`).

I tested this podspec to integrate TelemetryDeck in my own app, and it seems to be working.