### PR TITLE
Support customisable LogHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ A very small subset of our customers will want to use a custom signal ingestion 
 let configuration = TelemetryManagerConfiguration(appID: "<YOUR-APP-ID>", baseURL: "https://nom.telemetrydeck.com")
 ```
 
+## Custom Logging Strategy
+
+By default, some logs helpful for monitoring TelemetryDeck are printed out to the console. This behaviour can be customised by overriding `configuration.logHandler`. This struct accepts a minimum allows log level (any log with the same or higher log level will be accepted) and a closure.
+
+This allows for compatibility with other logging solutions, such as [swift-log](https://github.com/apple/swift-log), by providing your own closure.
+
 ## Developing this SDK
 
 Your PRs on TelemetryDeck's Swift Client are very much welcome. Check out the [SwiftClientTester](https://github.com/TelemetryDeck/SwiftClientTester) project, which provides a harness you can use to work on the library and try out new things.

--- a/Sources/TelemetryClient/LogHandler.swift
+++ b/Sources/TelemetryClient/LogHandler.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct LogHandler {
+    public enum LogLevel: Int, CustomStringConvertible {
+        case debug = 0
+        case info = 1
+        case error = 2
+        
+        public var description: String {
+            switch self {
+            case .debug:
+                return "DEBUG"
+            case .info:
+                return "INFO"
+            case .error:
+                return "ERROR"
+            }
+        }
+    }
+    
+    let logLevel: LogLevel
+    let handler: (LogLevel, String) -> Void
+    
+    internal func log(_ level: LogLevel = .info, message: String) {
+        if level.rawValue >= logLevel.rawValue {
+            handler(level, message)
+        }
+    }
+    
+    public static var stdout = { logLevel in
+        LogHandler(logLevel: logLevel) { level, message in
+            print("[TelemetryDeck: \(level.description)] \(message)")
+        }
+    }
+}

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -110,12 +110,17 @@ public final class TelemetryManagerConfiguration {
     ///
     /// Works together with `swiftUIPreviewMode` if either of those values is `true` no analytics events are sent.
     /// However it won't interfere with SwiftUI Previews, when explicitly settings this value to `false`.
-
     public var analyticsDisabled: Bool = false
 
     /// Log the current status to the signal cache to the console.
+    @available(*, deprecated, message: "Please use the logHandler property instead")
     public var showDebugLogs: Bool = false
-
+    
+    /// A strategy for handling logs.
+    ///
+    /// Defaults to `print` with info/errror messages - debug messages are not outputted. Set to `nil` to disable all logging from TelemetryDeck SDK.
+    public var logHandler: LogHandler? = LogHandler.stdout(.info)
+    
     public init(appID: String, salt: String? = nil, baseURL: URL? = nil) {
         telemetryAppID = appID
 

--- a/Tests/TelemetryClientTests/LogHandlerTests.swift
+++ b/Tests/TelemetryClientTests/LogHandlerTests.swift
@@ -1,0 +1,35 @@
+@testable import TelemetryClient
+import XCTest
+
+final class LogHandlerTests: XCTestCase {
+    func testLogHandler_stdoutLogLevelDefined() {
+        XCTAssertEqual(LogHandler.stdout(.error).logLevel, .error)
+    }
+    
+    func testLogHandler_logLevelRespected() {
+        var counter = 0
+        
+        let handler = LogHandler(logLevel: .info) { _, _ in
+            counter += 1
+        }
+        
+        XCTAssertEqual(counter, 0)
+        handler.log(.debug, message: "")
+        XCTAssertEqual(counter, 0)
+        handler.log(.info, message: "")
+        XCTAssertEqual(counter, 1)
+        handler.log(.error, message: "")
+        XCTAssertEqual(counter, 2)
+    }
+    
+    func testLogHandler_defaultLogLevel() {
+        var lastLevel: LogHandler.LogLevel?
+        
+        let handler = LogHandler(logLevel: .debug) { level, _ in
+            lastLevel = level
+        }
+        
+        handler.log(message: "")
+        XCTAssertEqual(lastLevel, .info)
+    }
+}

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -14,7 +14,7 @@ final class TelemetryClientTests: XCTestCase {
     }
     
     func testPushAndPop() {
-        let signalCache = SignalCache<SignalPostBody>(showDebugLogs: false)
+        let signalCache = SignalCache<SignalPostBody>(logHandler: nil)
         
         let signals: [SignalPostBody] = [
             .init(receivedAt: Date(), appID: UUID(), clientUser: "01", sessionID: "01", type: "test", floatValue: nil, payload: [], isTestMode: "true"),


### PR DESCRIPTION
By default, this will increase slightly the amount of logging that end clients see - however it is now far more configurable.

`showDebugLogs` has been deprecated with users being encouraged to use `logHandler`. The debug logs parameter is no longer used.

Closes #31 