### PR TITLE
send extension identifier, if provided

### DIFF
--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -54,6 +54,7 @@ internal struct SignalPayload: Codable {
     var operatingSystem: String = Self.operatingSystem
     var targetEnvironment: String = Self.targetEnvironment
     var locale: String = Self.locale
+    var extensionIdentifier: String? = Self.extensionIdentifier
     var telemetryClientVersion: String = TelemetryClientVersion
 
     let additionalPayload: [String: String]
@@ -156,6 +157,14 @@ extension SignalPayload {
     static var buildNumber: String {
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
         return buildNumber ?? "0"
+    }
+    
+    /// The extension identifer for the active resource, if available.
+    ///
+    /// This provides a value such as `com.apple.widgetkit-extension` when TelemetryDeck is run from a widget.
+    static var extensionIdentifier: String? {
+        let container = Bundle.main.infoDictionary?["NSExtension"] as? [String: Any]
+        return container?["NSExtensionPointIdentifier"] as? String
     }
 
     /// The modelname as reported by systemInfo.machine


### PR DESCRIPTION
iOS and other Apple operating systems have a plethora of extension types all with a unique identifier which can be retrieved from the Info.plist for the current target.

A complete list of identifiers can be found here: https://developer.apple.com/documentation/bundleresources/information_property_list/nsextension/nsextensionpointidentifier

It is useful for developers to understand the source of the events, including whether it came from a widget, notification service, or other extension.

Closes #29 

⚠️  - this will upload raw identifiers which may not be immediately understandable by developers. It would be nice to enrich or _prettyify_ this data by rendering the likes of "com.apple.widgetkit-extension" as "Widget Extension" or "com.apple.usernotifications.content-extension" as "Notification Content Extension". This would ideally be done on the backend in order to quickly support new identifiers added in the future, and in order to keep the SDK as light as possible. It's important we accept this piece of server-side work before merging this, else we need to add that same information into the SDK.