### PR TITLE
Add support for metadata enrichers

### DIFF
--- a/Sources/TelemetryClient/LogHandler.swift
+++ b/Sources/TelemetryClient/LogHandler.swift
@@ -5,7 +5,7 @@ public struct LogHandler {
         case debug = 0
         case info = 1
         case error = 2
-        
+
         public var description: String {
             switch self {
             case .debug:
@@ -17,16 +17,16 @@ public struct LogHandler {
             }
         }
     }
-    
+
     let logLevel: LogLevel
     let handler: (LogLevel, String) -> Void
-    
+
     internal func log(_ level: LogLevel = .info, message: String) {
         if level.rawValue >= logLevel.rawValue {
             handler(level, message)
         }
     }
-    
+
     public static var stdout = { logLevel in
         LogHandler(logLevel: logLevel) { level, message in
             print("[TelemetryDeck: \(level.description)] \(message)")

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -38,55 +38,40 @@ internal struct SignalPostBody: Codable, Equatable {
     let isTestMode: String
 }
 
-internal struct SignalPayload: Codable {
-    var platform: String = Self.platform
-    var systemVersion: String = Self.systemVersion
-    var majorSystemVersion: String = Self.majorSystemVersion
-    var majorMinorSystemVersion: String = Self.majorMinorSystemVersion
-    var appVersion: String = Self.appVersion
-    var buildNumber: String = Self.buildNumber
-    var isSimulator: String = "\(Self.isSimulator)"
-    var isDebug: String = "\(Self.isDebug)"
-    var isTestFlight: String = "\(Self.isTestFlight)"
-    var isAppStore: String = "\(Self.isAppStore)"
-    var modelName: String = Self.modelName
-    var architecture: String = Self.architecture
-    var operatingSystem: String = Self.operatingSystem
-    var targetEnvironment: String = Self.targetEnvironment
-    var locale: String = Self.locale
+internal struct DefaultSignalPayload: Encodable {
+    let platform = Self.platform
+    let systemVersion = Self.systemVersion
+    let majorSystemVersion = Self.majorSystemVersion
+    let majorMinorSystemVersion = Self.majorMinorSystemVersion
+    let appVersion = Self.appVersion
+    let buildNumber = Self.buildNumber
+    let isSimulator = "\(Self.isSimulator)"
+    let isDebug = "\(Self.isDebug)"
+    let isTestFlight = "\(Self.isTestFlight)"
+    let isAppStore = "\(Self.isAppStore)"
+    let modelName = Self.modelName
+    let architecture = Self.architecture
+    let operatingSystem = Self.operatingSystem
+    let targetEnvironment = Self.targetEnvironment
+    let locale = Self.locale
     var extensionIdentifier: String? = Self.extensionIdentifier
-    var telemetryClientVersion: String = TelemetryClientVersion
-
-    let additionalPayload: [String: String]
-}
-
-extension SignalPayload {
-    /// Converts the `additionalPayload` to a `[String: String]` dictionary
+    let telemetryClientVersion = TelemetryClientVersion
+    
     func toDictionary() -> [String: String] {
-        // We need to convert the additionalPayload into new key/value pairs
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
         do {
-            // Create a Dictionary
-            let jsonData = try encoder.encode(self)
-            var dict = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any]
-            // Remove the additionalPayload sub dictionary
-            dict?.removeValue(forKey: "additionalPayload")
-            // Add the additionalPayload as new key/value pairs
-            return dict?.merging(additionalPayload, uniquingKeysWith: { _, last in last }) as? [String: String] ?? [:]
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(self)
+            let dict = try JSONSerialization.jsonObject(with: data) as? [String: String]
+            return dict ?? [:]
         } catch {
             return [:]
         }
-    }
-
-    func toMultiValueDimension() -> [String] {
-        return toDictionary().map { key, value in key.replacingOccurrences(of: ":", with: "_") + ":" + value }
     }
 }
 
 // MARK: - Helpers
 
-extension SignalPayload {
+extension DefaultSignalPayload {
     static var isSimulatorOrTestFlight: Bool {
         isSimulator || isTestFlight
     }

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -56,7 +56,7 @@ internal struct DefaultSignalPayload: Encodable {
     let locale = Self.locale
     var extensionIdentifier: String? = Self.extensionIdentifier
     let telemetryClientVersion = TelemetryClientVersion
-    
+
     func toDictionary() -> [String: String] {
         do {
             let encoder = JSONEncoder()
@@ -143,7 +143,7 @@ extension DefaultSignalPayload {
         let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String
         return buildNumber ?? "0"
     }
-    
+
     /// The extension identifer for the active resource, if available.
     ///
     /// This provides a value such as `com.apple.widgetkit-extension` when TelemetryDeck is run from a widget.

--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -87,7 +87,7 @@ internal class SignalCache<T> where T: Codable {
 
         queue.sync {
             logHandler?.log(message: "Loading Telemetry cache from: \(fileURL())")
-            
+
             if let data = try? Data(contentsOf: fileURL()) {
                 // Loaded cache file, now delete it to stop it being loaded multiple times
                 try? FileManager.default.removeItem(at: fileURL())

--- a/Sources/TelemetryClient/SignalEnricher.swift
+++ b/Sources/TelemetryClient/SignalEnricher.swift
@@ -14,7 +14,7 @@ extension Dictionary where Key == String, Value == String {
             rhs
         }
     }
-    
+
     func toMultiValueDimension() -> [String] {
         map { key, value in
             key.replacingOccurrences(of: ":", with: "_") + ":" + value

--- a/Sources/TelemetryClient/SignalEnricher.swift
+++ b/Sources/TelemetryClient/SignalEnricher.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public protocol SignalEnricher {
+    func enrich(
+        signalType: String,
+        for clientUser: String?,
+        floatValue: Double?,
+        with additionalPayload: [String: String]
+    ) -> [String: String]
+}
+
+extension Dictionary where Key == String, Value == String {
+    func applying(_ rhs: [String: String]) -> [String: String] {
+        merging(rhs) { _, rhs in
+            rhs
+        }
+    }
+    
+    func toMultiValueDimension() -> [String] {
+        map { key, value in
+            key.replacingOccurrences(of: ":", with: "_") + ":" + value
+        }
+    }
+}

--- a/Sources/TelemetryClient/SignalEnricher.swift
+++ b/Sources/TelemetryClient/SignalEnricher.swift
@@ -2,10 +2,9 @@ import Foundation
 
 public protocol SignalEnricher {
     func enrich(
-        signalType: String,
+        signalType: TelemetrySignalType,
         for clientUser: String?,
-        floatValue: Double?,
-        with additionalPayload: [String: String]
+        floatValue: Double?
     ) -> [String: String]
 }
 

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -70,7 +70,9 @@ internal class SignalManager: SignalManageable {
     /// Adds a signal to the process queue
     func processSignal(_ signalType: TelemetrySignalType, for clientUser: String? = nil, floatValue: Double? = nil, with additionalPayload: [String: String] = [:], configuration: TelemetryManagerConfiguration) {
         DispatchQueue.global(qos: .utility).async {
-            let payLoad = SignalPayload(additionalPayload: additionalPayload)
+            let payload = DefaultSignalPayload().toDictionary()
+                .applying([:]) // enrichers
+                .applying(additionalPayload)
 
             let signalPostBody = SignalPostBody(
                 receivedAt: Date(),
@@ -79,7 +81,7 @@ internal class SignalManager: SignalManageable {
                 sessionID: configuration.sessionID.uuidString,
                 type: "\(signalType)",
                 floatValue: floatValue,
-                payload: payLoad.toMultiValueDimension(),
+                payload: payload.toMultiValueDimension(),
                 isTestMode: configuration.testMode ? "true" : "false"
             )
 

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -73,7 +73,7 @@ internal class SignalManager: SignalManageable {
             let enrichedMetadata: [String: String] = configuration.metadataEnrichers
                 .map { $0.enrich(signalType: signalType, for: clientUser, floatValue: floatValue) }
                 .reduce([String: String](), { $0.applying($1) })
-            
+
             let payload = DefaultSignalPayload().toDictionary()
                 .applying(enrichedMetadata)
                 .applying(additionalPayload)
@@ -104,7 +104,7 @@ internal class SignalManager: SignalManageable {
         let queuedSignals: [SignalPostBody] = signalCache.pop()
         if !queuedSignals.isEmpty {
             configuration.logHandler?.log(message: "Sending \(queuedSignals.count) signals leaving a cache of \(signalCache.count()) signals")
-            
+
             send(queuedSignals) { [configuration, signalCache] data, response, error in
 
                 if let error = error {
@@ -181,7 +181,7 @@ private extension SignalManager {
 
             urlRequest.httpBody = try! JSONEncoder.telemetryEncoder.encode(signalPostBodies)
             self.configuration.logHandler?.log(.debug, message: String(data: urlRequest.httpBody!, encoding: .utf8)!)
-            
+
             /// Wait for connectivity
             let config = URLSessionConfiguration.default
             config.waitsForConnectivity = true

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -208,12 +208,12 @@ private extension SignalManager {
         guard configuration.defaultUser == nil else { return configuration.defaultUser! }
 
         #if os(iOS) || os(tvOS)
-            return UIDevice.current.identifierForVendor?.uuidString ?? "unknown user \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+            return UIDevice.current.identifierForVendor?.uuidString ?? "unknown user \(DefaultSignalPayload.systemVersion) \(DefaultSignalPayload.buildNumber)"
         #elseif os(watchOS)
             if #available(watchOS 6.2, *) {
-                return WKInterfaceDevice.current().identifierForVendor?.uuidString ?? "unknown user \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+                return WKInterfaceDevice.current().identifierForVendor?.uuidString ?? "unknown user \(DefaultSignalPayload.systemVersion) \(DefaultSignalPayload.buildNumber)"
             } else {
-                return "unknown user \(SignalPayload.platform) \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+                return "unknown user \(DefaultSignalPayload.platform) \(DefaultSignalPayload.systemVersion) \(DefaultSignalPayload.buildNumber)"
             }
         #elseif os(macOS)
             if let customDefaults = self.customDefaults, let defaultUserIdentifier = customDefaults.string(forKey: "defaultUserIdentifier") {
@@ -227,7 +227,7 @@ private extension SignalManager {
             #if DEBUG
                 configuration.logHandler?.log(message: "[Telemetry] On this platform, Telemetry can't generate a unique user identifier. It is recommended you supply one yourself. More info: https://telemetrydeck.com/pages/signal-reference.html")
             #endif
-            return "unknown user \(SignalPayload.platform) \(SignalPayload.systemVersion) \(SignalPayload.buildNumber)"
+            return "unknown user \(DefaultSignalPayload.platform) \(DefaultSignalPayload.systemVersion) \(DefaultSignalPayload.buildNumber)"
         #endif
     }
 }

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -121,6 +121,11 @@ public final class TelemetryManagerConfiguration {
     /// Defaults to `print` with info/errror messages - debug messages are not outputted. Set to `nil` to disable all logging from TelemetryDeck SDK.
     public var logHandler: LogHandler? = LogHandler.stdout(.info)
     
+    /// An array of signal metadata enrichers: a system for adding dynamic metadata to signals as they are recorded.
+    ///
+    /// Defaults to an empty array.
+    public var metadataEnrichers: [SignalEnricher] = []
+    
     public init(appID: String, salt: String? = nil, baseURL: URL? = nil) {
         telemetryAppID = appID
 

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -115,17 +115,17 @@ public final class TelemetryManagerConfiguration {
     /// Log the current status to the signal cache to the console.
     @available(*, deprecated, message: "Please use the logHandler property instead")
     public var showDebugLogs: Bool = false
-    
+
     /// A strategy for handling logs.
     ///
     /// Defaults to `print` with info/errror messages - debug messages are not outputted. Set to `nil` to disable all logging from TelemetryDeck SDK.
     public var logHandler: LogHandler? = LogHandler.stdout(.info)
-    
+
     /// An array of signal metadata enrichers: a system for adding dynamic metadata to signals as they are recorded.
     ///
     /// Defaults to an empty array.
     public var metadataEnrichers: [SignalEnricher] = []
-    
+
     public init(appID: String, salt: String? = nil, baseURL: URL? = nil) {
         telemetryAppID = appID
 

--- a/Tests/TelemetryClientTests/SignalPayloadTests.swift
+++ b/Tests/TelemetryClientTests/SignalPayloadTests.swift
@@ -1,65 +1,65 @@
 @testable import TelemetryClient
 import XCTest
 
-final class SignalPayloadTests: XCTestCase {
+final class DefaultSignalPayloadTests: XCTestCase {
     func testIsSimulatorOrTestFlight() {
-        XCTAssertNoThrow(SignalPayload.isSimulatorOrTestFlight)
-        print("isSimulatorOrTestFlight", SignalPayload.isSimulatorOrTestFlight)
+        XCTAssertNoThrow(DefaultSignalPayload.isSimulatorOrTestFlight)
+        print("isSimulatorOrTestFlight", DefaultSignalPayload.isSimulatorOrTestFlight)
     }
     
     func testIsSimulator() {
-        XCTAssertNoThrow(SignalPayload.isSimulator)
-        print("isSimulator", SignalPayload.isSimulator)
+        XCTAssertNoThrow(DefaultSignalPayload.isSimulator)
+        print("isSimulator", DefaultSignalPayload.isSimulator)
     }
     
     func testIsDebug() {
-        XCTAssertTrue(SignalPayload.isDebug)
-        print("isDebug", SignalPayload.isDebug)
+        XCTAssertTrue(DefaultSignalPayload.isDebug)
+        print("isDebug", DefaultSignalPayload.isDebug)
     }
     
     func testIsTestFlight() {
-        XCTAssertFalse(SignalPayload.isTestFlight)
-        print("isTestFlight", SignalPayload.isTestFlight)
+        XCTAssertFalse(DefaultSignalPayload.isTestFlight)
+        print("isTestFlight", DefaultSignalPayload.isTestFlight)
     }
     
     func testIsAppStore() {
-        XCTAssertFalse(SignalPayload.isAppStore)
-        print("isAppStore", SignalPayload.isAppStore)
+        XCTAssertFalse(DefaultSignalPayload.isAppStore)
+        print("isAppStore", DefaultSignalPayload.isAppStore)
     }
     
     func testSystemVersion() {
-        XCTAssertNoThrow(SignalPayload.systemVersion)
-        print("systemVersion", SignalPayload.systemVersion)
+        XCTAssertNoThrow(DefaultSignalPayload.systemVersion)
+        print("systemVersion", DefaultSignalPayload.systemVersion)
     }
     
     func testMajorSystemVersion() {
-        XCTAssertNoThrow(SignalPayload.majorSystemVersion)
-        print("majorSystemVersion", SignalPayload.majorSystemVersion)
+        XCTAssertNoThrow(DefaultSignalPayload.majorSystemVersion)
+        print("majorSystemVersion", DefaultSignalPayload.majorSystemVersion)
     }
     
     func testMajorMinorSystemVersion() {
-        XCTAssertNoThrow(SignalPayload.majorMinorSystemVersion)
-        print("majorMinorSystemVersion", SignalPayload.majorMinorSystemVersion)
+        XCTAssertNoThrow(DefaultSignalPayload.majorMinorSystemVersion)
+        print("majorMinorSystemVersion", DefaultSignalPayload.majorMinorSystemVersion)
     }
     
     func testAppVersion() {
-        XCTAssertNoThrow(SignalPayload.appVersion)
-        print("appVersion", SignalPayload.appVersion)
+        XCTAssertNoThrow(DefaultSignalPayload.appVersion)
+        print("appVersion", DefaultSignalPayload.appVersion)
     }
     
     func testBuildNumber() {
-        XCTAssertNoThrow(SignalPayload.buildNumber)
-        print("buildNumber", SignalPayload.buildNumber)
+        XCTAssertNoThrow(DefaultSignalPayload.buildNumber)
+        print("buildNumber", DefaultSignalPayload.buildNumber)
     }
     
     func testModelName() {
-        XCTAssertNoThrow(SignalPayload.modelName)
-        print("modelName", SignalPayload.modelName)
+        XCTAssertNoThrow(DefaultSignalPayload.modelName)
+        print("modelName", DefaultSignalPayload.modelName)
     }
     
     func testArchitecture() {
-        XCTAssertNoThrow(SignalPayload.architecture)
-        print("architecture", SignalPayload.architecture)
+        XCTAssertNoThrow(DefaultSignalPayload.architecture)
+        print("architecture", DefaultSignalPayload.architecture)
     }
     
     func testOperatingSystem() {
@@ -79,23 +79,23 @@ final class SignalPayloadTests: XCTestCase {
             return "Unknown Operating System"
         #endif
         
-        XCTAssertEqual(expectedResult, SignalPayload.operatingSystem)
+        XCTAssertEqual(expectedResult, DefaultSignalPayload.operatingSystem)
         
-        print("operatingSystem", SignalPayload.operatingSystem)
+        print("operatingSystem", DefaultSignalPayload.operatingSystem)
     }
     
     func testPlatform() {
-        XCTAssertNoThrow(SignalPayload.platform)
-        print("platform", SignalPayload.platform)
+        XCTAssertNoThrow(DefaultSignalPayload.platform)
+        print("platform", DefaultSignalPayload.platform)
     }
     
     func testTargetEnvironment() {
-        XCTAssertNoThrow(SignalPayload.targetEnvironment)
-        print("targetEnvironment", SignalPayload.targetEnvironment)
+        XCTAssertNoThrow(DefaultSignalPayload.targetEnvironment)
+        print("targetEnvironment", DefaultSignalPayload.targetEnvironment)
     }
     
     func testLocale() {
-        XCTAssertNoThrow(SignalPayload.locale)
-        print("locale", SignalPayload.locale)
+        XCTAssertNoThrow(DefaultSignalPayload.locale)
+        print("locale", DefaultSignalPayload.locale)
     }
 }

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -134,7 +134,8 @@ private class FakeSignalManager: SignalManageable {
     func processSignal(_ signalType: TelemetrySignalType, for clientUser: String?, floatValue: Double?, with additionalPayload: [String : String], configuration: TelemetryManagerConfiguration) {
         processedSignalTypes.append(signalType)
         
-        let payLoad = SignalPayload(additionalPayload: additionalPayload)
+        let payload = DefaultSignalPayload().toDictionary()
+            .applying(additionalPayload)
         
         let signalPostBody = SignalPostBody(
             receivedAt: Date(),
@@ -143,7 +144,7 @@ private class FakeSignalManager: SignalManageable {
             sessionID: configuration.sessionID.uuidString,
             type: "\(signalType)",
             floatValue: floatValue,
-            payload: payLoad.toMultiValueDimension(),
+            payload: payload.toMultiValueDimension(),
             isTestMode: configuration.testMode ? "true" : "false"
         )
         processedSignals.append(signalPostBody)


### PR DESCRIPTION
Inspired by the Kotlin solution, you can now register enrichers to the configuration class.

Priority is in order of:

1. The metadata provided at the `.send` callsite
2. The metadata enrichers with the last enricher added having priority over the first
3. The default payload provided by this SDK

Closes #47 