### PR TITLE
Do not block calling queue with IO operations of `SignalCache`

### DIFF
--- a/Sources/TelemetryClient/SignalCache.swift
+++ b/Sources/TelemetryClient/SignalCache.swift
@@ -63,9 +63,9 @@ internal class SignalCache<T> where T: Codable {
         return cacheFolderURL.appendingPathComponent("telemetrysignalcache")
     }
 
-    /// Save the entire signal cache to disk
+    /// Save the entire signal cache to disk asynchronously
     func backupCache() {
-        queue.sync {
+        queue.async { [self] in
             if let data = try? JSONEncoder().encode(self.cachedSignals) {
                 do {
                     try data.write(to: fileURL())
@@ -81,16 +81,17 @@ internal class SignalCache<T> where T: Codable {
         }
     }
 
-    /// Loads any previous signal cache from disk
+    /// Loads any previous signal cache from disk asynchronously
     init(logHandler: LogHandler?) {
         self.logHandler = logHandler
 
-        queue.sync {
-            logHandler?.log(message: "Loading Telemetry cache from: \(fileURL())")
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.logHandler?.log(message: "Loading Telemetry cache from: \(self.fileURL())")
 
-            if let data = try? Data(contentsOf: fileURL()) {
+            if let data = try? Data(contentsOf: self.fileURL()) {
                 // Loaded cache file, now delete it to stop it being loaded multiple times
-                try? FileManager.default.removeItem(at: fileURL())
+                try? FileManager.default.removeItem(at: self.fileURL())
 
                 // Decode the data into a new cache
                 if let signals = try? JSONDecoder().decode([T].self, from: data) {


### PR DESCRIPTION
`SignalCache` used to dispatch synchronously instead of asynchronously to its concurrent queue for the I/O operations of loading the cache and backing up the cache to file system which are typically done on app launch and when the app is sent to background respectively. Given how these functions are called, these would be typically blocking the main thread.