### PR TITLE
Remove `waitsForConnectivity`

### DIFF
--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -182,11 +182,7 @@ private extension SignalManager {
             urlRequest.httpBody = try! JSONEncoder.telemetryEncoder.encode(signalPostBodies)
             self.configuration.logHandler?.log(.debug, message: String(data: urlRequest.httpBody!, encoding: .utf8)!)
 
-            /// Wait for connectivity
-            let config = URLSessionConfiguration.default
-            config.waitsForConnectivity = true
-            let session = URLSession(configuration: config)
-            let task = session.dataTask(with: urlRequest, completionHandler: completionHandler)
+            let task = URLSession.shared.dataTask(with: urlRequest, completionHandler: completionHandler)
             task.resume()
         }
     }


### PR DESCRIPTION
As mentioned in https://github.com/TelemetryDeck/SwiftClient/issues/52, setting `waitsForConnectivity` causes all events that occur when there is no network connection to be lost when an app is quit.

I don't really see any need to check for network connection before calling send, with this change the dataTask will instantly fail and return an error (adding the signals back to the queue) since URLSession is checking the NWPath anyway.