### PR TITLE
New force-sync method (load-capped) to track bad experiences that might lead users to leave/delete app (improved churn tracking)

### DIFF
--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -222,7 +222,7 @@ extension DefaultSignalPayload {
     static var operatingSystem: String {
         #if os(macOS)
             return "macOS"
-        #elseif os(xrOS)
+        #elseif os(visionOS)
             return "visionOS"
         #elseif os(iOS)
             return "iOS"
@@ -240,7 +240,7 @@ extension DefaultSignalPayload {
     static var platform: String {
         #if os(macOS)
             return "macOS"
-        #elseif os(xrOS)
+        #elseif os(visionOS)
             return "visionOS"
         #elseif os(iOS)
             #if targetEnvironment(macCatalyst)

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if os(iOS) || os(xrOS)
+#if os(iOS) || os(visionOS)
 import UIKit
 #elseif os(macOS)
 import AppKit
@@ -213,7 +213,7 @@ private extension SignalManager {
     var defaultUserIdentifier: String {
         guard configuration.defaultUser == nil else { return configuration.defaultUser! }
 
-        #if os(iOS) || os(tvOS) || os(xrOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
             return UIDevice.current.identifierForVendor?.uuidString ?? "unknown user \(DefaultSignalPayload.systemVersion) \(DefaultSignalPayload.buildNumber)"
         #elseif os(watchOS)
             if #available(watchOS 6.2, *) {

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -25,7 +25,7 @@ internal class SignalManager: SignalManageable {
         self.configuration = configuration
 
         // We automatically load any old signals from disk on initialisation
-        signalCache = SignalCache(logHandler: configuration.logHandler)
+        signalCache = SignalCache(logHandler: configuration.swiftUIPreviewMode ? nil : configuration.logHandler)
 
         // Before the app terminates, we want to save any pending signals to disk
         // We need to monitor different notifications for different devices.

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -46,7 +46,7 @@ internal class SignalManager: SignalManageable {
         } else {
             // Pre watchOS 7.0, this library will not use disk caching at all as there are no notifications we can observe.
         }
-        #elseif os(tvOS) || os(iOS)
+        #elseif os(tvOS) || os(iOS) || os(visionOS)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             // We need to use a delay with these type of notifications because they fire on app load which causes a double load of the cache from disk
             NotificationCenter.default.addObserver(self, selector: #selector(self.didEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
@@ -148,7 +148,7 @@ private extension SignalManager {
     /// This means our `init()` above doesn't always run when coming back to foreground, so we have to manually
     /// reload the cache. This also means we miss any signals sent during watchDidEnterForeground
     /// so we merge them into the new cache.
-    #if os(watchOS) || os(tvOS) || os(iOS)
+    #if os(watchOS) || os(tvOS) || os(iOS) || os(visionOS)
     @objc func didEnterForeground() {
         configuration.logHandler?.log(.debug, message: #function)
 

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -119,6 +119,8 @@ public final class TelemetryManagerConfiguration {
     /// A strategy for handling logs.
     ///
     /// Defaults to `print` with info/errror messages - debug messages are not outputted. Set to `nil` to disable all logging from TelemetryDeck SDK.
+    ///
+    /// - NOTE: If ``swiftUIPreviewMode`` is `true` (by default only when running SwiftUI previews), this value is effectively ignored, working like it's set to `nil`.
     public var logHandler: LogHandler? = LogHandler.stdout(.info)
 
     /// An array of signal metadata enrichers: a system for adding dynamic metadata to signals as they are recorded.

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -277,7 +277,11 @@ public class TelemetryManager {
         // this check ensures that the number of requests can only double in the worst case where a developer calls this after each `send`
         if Date().timeIntervalSince(lastTimeImmediateSyncRequested) > SignalManager.minimumSecondsToPassBetweenRequests {
             lastTimeImmediateSyncRequested = Date()
-            signalManager.attemptToSendNextBatchOfCachedSignals()
+
+            // give the signal manager some short amount of time to process the signal that was sent right before calling sync
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + .milliseconds(50)) { [weak self] in
+                self?.signalManager.attemptToSendNextBatchOfCachedSignals()
+            }
         }
     }
 

--- a/Tests/TelemetryClientTests/SignalPayloadTests.swift
+++ b/Tests/TelemetryClientTests/SignalPayloadTests.swift
@@ -75,7 +75,7 @@ final class DefaultSignalPayloadTests: XCTestCase {
             expectedResult = "tvOS"
         #elseif os(Linux)
             expectedResult = "Linux"
-        #elseif os(xrOS)
+        #elseif os(visionOS)
             expectedResult = "VisionOS"
         #else
             return "Unknown Operating System"

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -194,4 +194,6 @@ private class FakeSignalManager: SignalManageable {
         )
         processedSignals.append(signalPostBody)
     }
+
+    func attemptToSendNextBatchOfCachedSignals() {}
 }


### PR DESCRIPTION
Individual commits:
* [Update checks for temporary name xrOS to final visionOS](https://github.com/TelemetryDeck/SwiftClient/commit/f6d6eab72ee78f2afffc9092d44439a8ab636607)
* [Simple patch to ensure nothing is logged in SwiftUI preview mode](https://github.com/TelemetryDeck/SwiftClient/commit/fc6f2447f204317797525a40b6c2e3e054db2a82)
* [Refactor some function & property naming in SignalManager for more clarity + update docs](https://github.com/TelemetryDeck/SwiftClient/commit/389837d4e54570055a79b03013bbf09c54c04362) 
* [React to background/foreground changes on visionOS](https://github.com/TelemetryDeck/SwiftClient/commit/ed1a28152ee10a368890b37097da7f5fb16db542)
* [Add new method TelemetryClient.requestImmediateSync() for advanced churn optimization](https://github.com/TelemetryDeck/SwiftClient/commit/22558423837cad54cb4079f22a983850962ad7b1) 

Some functions in `SignalManager` seemed to have been named after planned behavior that was never implemented.
Therefore, the function names & docs were somewhat misleading. I adjusted the names to reflect what they actually do.

The new method `.requestImmediateSync()` fixes #130 and should only be used in rare cases where important information is sent to the servers that must reach the servers even if the user might leave the app right after and never return. This can be useful for apps that are used only once to track important last steps of the user. Or for experiences like errors that could make the user delete the app right after. Those error signals would never reach the server without this.

This PR also fixes #134 (a minor SwifUI logging issue).
It also fixes some warnings regarding `visionOS` (instead of `xrOS`) & improves Vison Pro support.