### PR TITLE
[TelemetryManager] Replace fatalError With assertionFailure

### DIFF
--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -224,7 +224,8 @@ public class TelemetryManager {
             self.initializedTelemetryManager = .init(configuration: .init(appID: ""))
             return self.initializedTelemetryManager!
         } else {
-            fatalError("Please call TelemetryManager.initialize(...) before accessing the shared telemetryManager instance.")
+            assertionFailure("Please call TelemetryManager.initialize(...) before accessing the shared telemetryManager instance.")
+            return .init(configuration: .init(appID: ""))
         }
 
     }


### PR DESCRIPTION
Replace `fatalError(_:file:line:)` with `assertionFailure(_:file:line:)` to catch uninitialized `TelemetryManager.shared` without crashing in release builds.

See issue #112 for context.