### PR TITLE
Make it easier to check for appLanguage, preferredLanguage, and region + grand rename

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,4 @@
-// swift-tools-version:5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -9,7 +7,8 @@ let package = Package(
         .macOS(.v10_13),
         .iOS(.v12),
         .watchOS(.v5),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -55,6 +55,9 @@ public struct DefaultSignalPayload: Encodable {
     public let operatingSystem = Self.operatingSystem
     public let targetEnvironment = Self.targetEnvironment
     public let locale = Self.locale
+    public let region = Self.region
+    public let appLanguage = Self.appLanguage
+    public let preferredLanguage = Self.preferredLanguage
     public let extensionIdentifier: String? = Self.extensionIdentifier
     public let telemetryClientVersion = TelemetryClientVersion
 
@@ -271,8 +274,32 @@ extension DefaultSignalPayload {
         #endif
     }
 
-    /// The locale identifier
+    /// The locale identifier the app currently runs in. E.g. `en_DE` for an app that does not support German on a device with preferences `[German, English]`, and region Germany.
     static var locale: String {
         return Locale.current.identifier
+    }
+
+    /// The region identifier both the user most prefers and also the app is set to. They are always the same because formatters in apps always auto-adjust to the users preferences.
+    static var region: String {
+        if #available(iOS 16, macOS 13, tvOS 16, visionOS 1, watchOS 9, *) {
+            return Locale.current.region?.identifier ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_")).last!
+        } else {
+            return Locale.current.regionCode ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_")).last!
+        }
+    }
+
+    /// The language identifier the app is currently running in. This represents the language the system (or the user) has chosen for the app to run in.
+    static var appLanguage: String {
+        if #available(iOS 16, macOS 13, tvOS 16, visionOS 1, watchOS 9, *) {
+            return Locale.current.language.minimalIdentifier
+        } else {
+            return Locale.current.languageCode ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_"))[0]
+        }
+    }
+
+    /// The language identifier of the users most preferred language set on the device. Returns also languages the current app is not even localized to.
+    static var preferredLanguage: String {
+        let preferredLocaleIdentifier = Locale.preferredLanguages.first ?? "zz-ZZ"
+        return preferredLocaleIdentifier.components(separatedBy: .init(charactersIn: "-_"))[0]
     }
 }

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -101,7 +101,7 @@ public struct DefaultSignalPayload: Encodable {
             parameters["extensionIdentifier"] = extensionIdentifier
 
             // new name
-            parameters["TelemetryDeck.RunContext.extensionIdentifier"]
+            parameters["TelemetryDeck.RunContext.extensionIdentifier"] = extensionIdentifier
         }
 
         return parameters

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -79,7 +79,7 @@ internal class SignalManager: SignalManageable {
                 .map { $0.enrich(signalType: signalType, for: clientUser, floatValue: floatValue) }
                 .reduce([String: String](), { $0.applying($1) })
 
-            let payload = DefaultSignalPayload().toDictionary()
+            let payload = DefaultSignalPayload.parameters
                 .applying(enrichedMetadata)
                 .applying(additionalPayload)
 

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -10,7 +10,7 @@ import Foundation
     import TVUIKit
 #endif
 
-let TelemetryClientVersion = "SwiftClient 1.5.1"
+let TelemetryClientVersion = "1.5.1"
 
 public typealias TelemetrySignalType = String
 


### PR DESCRIPTION
In Swift, `Locale.current` represents the language and region the app is currently using. When an app is not localized to say German, for example, the identifier will not return `de` for the language even it's the users preferred language.

To make it easier for TelemetryDeck users to use a data-driven approach in deciding which languages to localize for next, it is important to add the preferred language of the user though, even if the app doesn't support it. It can also be useful to see just the app language or just the region, without them being clutched together in `locale` as in `en_DE`.

This PR therefore introduces `region` (the regional part of `locale`), `appLanguage` (the language part of `locale`), and the new `preferredLanguage` which is the field that is most useful to make the localization expansion decision.