### PR TITLE
Make it easier to check for appLanguage, preferredLanguage, and region + grand rename

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
         with:
           xcode-version: ${{ matrix.xcode }}
       - name: Build and Test
-        run: xcodebuild test -scheme TelemetryClient ${{ matrix.xcodebuildCommand }}
+        run: xcodebuild test -scheme TelemetryClient-Package ${{ matrix.xcodebuildCommand }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,11 @@ jobs:
         xcode:
           - ^15
         xcodebuildCommand:
-          - "-sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'"
+          - "-sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15'"
           - "-sdk macosx -destination 'platform=macOS'"
-          - "-sdk appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV 4K (2nd generation)'"
-          - "-sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (45mm)'"
+          - "-sdk xrsimulator -destination 'platform=visionOS Simulator,name=Apple Vision Pro'"
+          - "-sdk appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'"
+          - "-sdk watchsimulator -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)'"
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,7 @@ jobs:
       fail-fast: true
       matrix:
         xcode:
-          - ^14
-          # - ^15
+          - ^15
         xcodebuildCommand:
           - "-sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14'"
           - "-sdk macosx -destination 'platform=macOS'"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,12 +10,14 @@ on:
 jobs:
   lint:
     name: Lint Code
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4
       - name: Lint
-        run: swiftlint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict
   test:
     name: Test Xcode ${{ matrix.xcode }} - ${{ matrix.xcodebuildCommand }}
     runs-on: "macos-latest"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,5 @@
 # By default, SwiftLint uses a set of sensible default rules you can adjust:
 disabled_rules: # rule identifiers turned on by default to exclude from running
-  - identifier_name
   - function_body_length
   - opening_brace
   - trailing_comma

--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,16 @@ let package = Package(
         .visionOS(.v1),
     ],
     products: [
-        .library(name: "TelemetryDeck", targets: ["TelemetryClient"]),  // new name
+        .library(name: "TelemetryDeck", targets: ["TelemetryDeck"]),  // new name
         .library(name: "TelemetryClient", targets: ["TelemetryClient"]),  // old name
     ],
     dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "TelemetryDeck",
+            dependencies: ["TelemetryClient"],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
+        ),
         .target(
             name: "TelemetryClient",
             resources: [.copy("PrivacyInfo.xcprivacy")]

--- a/Package.swift
+++ b/Package.swift
@@ -11,16 +11,10 @@ let package = Package(
         .visionOS(.v1),
     ],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "TelemetryClient",
-            targets: ["TelemetryClient"]
-        ),
+        .library(name: "TelemetryDeck", targets: ["TelemetryClient"]),  // new name
+        .library(name: "TelemetryClient", targets: ["TelemetryClient"]),  // old name
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,4 @@
-// swift-tools-version:5.7
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
@@ -9,7 +7,8 @@ let package = Package(
         .macOS(.v10_13),
         .iOS(.v12),
         .watchOS(.v5),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/TelemetryClient/CryptoHashing.swift
+++ b/Sources/TelemetryClient/CryptoHashing.swift
@@ -11,8 +11,8 @@ enum CryptoHashing {
     /// should be preferred where available.
     /// [CommonCrypto](https://github.com/apple-oss-distributions/CommonCrypto) provides compatibility with older OS versions,
     /// apps built with Xcode versions lower than 11 and non-Apple platforms like Linux.
-    static func sha256(str: String, salt: String) -> String {
-        if let strData = (str + salt).data(using: String.Encoding.utf8) {
+    static func sha256(string: String, salt: String) -> String {
+        if let strData = (string + salt).data(using: String.Encoding.utf8) {
             #if canImport(CryptoKit)
                 if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *) {
                     let digest = SHA256.hash(data: strData)

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -61,13 +61,13 @@ public struct DefaultSignalPayload: Encodable {
             "region": Self.region,
             "appLanguage": Self.appLanguage,
             "preferredLanguage": Self.preferredLanguage,
-            "telemetryClientVersion": TelemetryClientVersion,
+            "telemetryClientVersion": telemetryClientVersion,
 
             // new names
             "TelemetryDeck.AppInfo.buildNumber": Self.buildNumber,
             "TelemetryDeck.AppInfo.version": Self.appVersion,
             "TelemetryDeck.AppInfo.versionAndBuildNumber": "\(Self.appVersion) (build \(Self.buildNumber))",
-            
+
             "TelemetryDeck.Device.architecture": Self.architecture,
             "TelemetryDeck.Device.modelName": Self.modelName,
             "TelemetryDeck.Device.operatingSystem": Self.operatingSystem,
@@ -89,8 +89,8 @@ public struct DefaultSignalPayload: Encodable {
             "TelemetryDeck.RunContext.targetEnvironment": Self.targetEnvironment,
 
             "TelemetryDeck.SDK.name": "SwiftSDK",
-            "TelemetryDeck.SDK.nameAndVersion": "SwiftSDK \(TelemetryClientVersion)",
-            "TelemetryDeck.SDK.version": TelemetryClientVersion,
+            "TelemetryDeck.SDK.nameAndVersion": "SwiftSDK \(telemetryClientVersion)",
+            "TelemetryDeck.SDK.version": telemetryClientVersion,
 
             "TelemetryDeck.UserPreference.language": Self.preferredLanguage,
             "TelemetryDeck.UserPreference.region": Self.region,
@@ -210,7 +210,7 @@ extension DefaultSignalPayload {
                 var modelIdentifier: String?
 
                 if let modelData = IORegistryEntryCreateCFProperty(service, "model" as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? Data {
-                    if let modelIdentifierCString = String(data: modelData, encoding: .utf8)?.cString(using: .utf8) {
+                    if let modelIdentifierCString = String(decoding: modelData, as: UTF8.self).cString(using: .utf8) {
                         modelIdentifier = String(cString: modelIdentifierCString)
                     }
                 }

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -55,6 +55,9 @@ public struct DefaultSignalPayload: Encodable {
     public let operatingSystem = Self.operatingSystem
     public let targetEnvironment = Self.targetEnvironment
     public let locale = Self.locale
+    public let region = Self.region
+    public let appLanguage = Self.appLanguage
+    public let preferredLanguage = Self.preferredLanguage
     public let extensionIdentifier: String? = Self.extensionIdentifier
     public let telemetryClientVersion = TelemetryClientVersion
 
@@ -271,8 +274,32 @@ extension DefaultSignalPayload {
         #endif
     }
 
-    /// The locale identifier
+    /// The locale identifier the app currently runs in. E.g. `en_DE` for an app that does not support German on a device with preferences `[German, English]`, and region Germany.
     static var locale: String {
         return Locale.current.identifier
+    }
+
+    /// The region identifier both the user most prefers and also the app is set to. They are always the same because formatters in apps always auto-adjust to the users preferences.
+    static var region: String {
+        if #available(iOS 16, macOS 13, tvOS 16, visionOS 1, watchOS 9, *) {
+            return Locale.current.region?.identifier ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_")).last!
+        } else {
+            return Locale.current.regionCode ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_")).last!
+        }
+    }
+
+    /// The language identifier the app is currently running in. This represents the language the system (or the user) has chosen for the app to run in.
+    static var appLanguage: String {
+        if #available(iOS 16, macOS 13, tvOS 16, visionOS 1, watchOS 9, *) {
+            return Locale.current.language.minimalIdentifier
+        } else {
+            return Locale.current.languageCode ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_"))[0]
+        }
+    }
+
+    /// The language identifier of the users most preferred language set on the device. Returns also languages the current app is not even localized to.
+    static var preferredLanguage: String {
+        let preferredLocaleIdentifier = Locale.preferredLanguages.first ?? "zz-ZZ"
+        return preferredLocaleIdentifier.components(separatedBy: .init(charactersIn: "-_"))[0]
     }
 }

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -324,7 +324,7 @@ extension DefaultSignalPayload {
     /// The language identifier the app is currently running in. This represents the language the system (or the user) has chosen for the app to run in.
     static var appLanguage: String {
         if #available(iOS 16, macOS 13, tvOS 16, visionOS 1, watchOS 9, *) {
-            return Locale.current.language.minimalIdentifier
+            return Locale.current.language.languageCode?.identifier ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_"))[0]
         } else {
             return Locale.current.languageCode ?? Locale.current.identifier.components(separatedBy: .init(charactersIn: "-_"))[0]
         }

--- a/Sources/TelemetryClient/Signal.swift
+++ b/Sources/TelemetryClient/Signal.swift
@@ -101,7 +101,7 @@ public struct DefaultSignalPayload: Encodable {
             parameters["extensionIdentifier"] = extensionIdentifier
 
             // new name
-            parameters["TelemetryDeck.RunContext.extensionIdentifier"]
+            parameters["TelemetryDeck.RunContext.extensionIdentifier"] = extensionIdentifier
         }
 
         return parameters

--- a/Sources/TelemetryClient/SignalEnricher.swift
+++ b/Sources/TelemetryClient/SignalEnricher.swift
@@ -9,9 +9,9 @@ public protocol SignalEnricher {
 }
 
 extension Dictionary where Key == String, Value == String {
-    func applying(_ rhs: [String: String]) -> [String: String] {
-        merging(rhs) { _, rhs in
-            rhs
+    func applying(_ other: [String: String]) -> [String: String] {
+        merging(other) { _, other in
+            other
         }
     }
 

--- a/Sources/TelemetryClient/SignalEnricher.swift
+++ b/Sources/TelemetryClient/SignalEnricher.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol SignalEnricher {
     func enrich(
-        signalType: TelemetrySignalType,
+        signalType: String,
         for clientUser: String?,
         floatValue: Double?
     ) -> [String: String]

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -86,7 +86,7 @@ internal class SignalManager: SignalManageable {
             let signalPostBody = SignalPostBody(
                 receivedAt: Date(),
                 appID: UUID(uuidString: configuration.telemetryAppID)!,
-                clientUser: CryptoHashing.sha256(str: customUserID ?? self.defaultUserIdentifier, salt: configuration.salt),
+                clientUser: CryptoHashing.sha256(string: customUserID ?? self.defaultUserIdentifier, salt: configuration.salt),
                 sessionID: configuration.sessionID.uuidString,
                 type: "\(signalName)",
                 floatValue: floatValue,
@@ -203,7 +203,7 @@ private extension SignalManager {
     #if os(macOS)
     /// A custom ``UserDefaults`` instance specific to TelemetryDeck and the current application.
     private var customDefaults: UserDefaults? {
-        let appIdHash = CryptoHashing.sha256(str: self.configuration.telemetryAppID, salt: "")
+        let appIdHash = CryptoHashing.sha256(string: self.configuration.telemetryAppID, salt: "")
         return UserDefaults(suiteName: "com.telemetrydeck.\(appIdHash.suffix(12))")
     }
     #endif

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -79,7 +79,7 @@ internal class SignalManager: SignalManageable {
                 .map { $0.enrich(signalType: signalType, for: clientUser, floatValue: floatValue) }
                 .reduce([String: String](), { $0.applying($1) })
 
-            let payload = DefaultSignalPayload().toDictionary()
+            let payload = DefaultSignalPayload.parameters
                 .applying(enrichedMetadata)
                 .applying(additionalPayload)
 

--- a/Sources/TelemetryClient/SignalManager.swift
+++ b/Sources/TelemetryClient/SignalManager.swift
@@ -130,7 +130,7 @@ internal class SignalManager: SignalManageable {
                 }
 
                 if let data = data {
-                    configuration.logHandler?.log(.debug, message: String(data: data, encoding: .utf8)!)
+                    configuration.logHandler?.log(.debug, message: String(decoding: data, as: UTF8.self))
                 }
             }
         }
@@ -189,7 +189,7 @@ private extension SignalManager {
             }
 
             urlRequest.httpBody = body
-            self.configuration.logHandler?.log(.debug, message: String(data: urlRequest.httpBody!, encoding: .utf8)!)
+            self.configuration.logHandler?.log(.debug, message: String(decoding: urlRequest.httpBody!, as: UTF8.self))
 
             let task = URLSession.shared.dataTask(with: urlRequest, completionHandler: completionHandler)
             task.resume()
@@ -253,13 +253,13 @@ private extension URLResponse {
         // Check for valid response in the 200-299 range
         guard (200 ... 299).contains(statusCode() ?? 0) else {
             if statusCode() == 401 {
-                return TelemetryError.Unauthorised
+                return TelemetryError.unauthorised
             } else if statusCode() == 403 {
-                return TelemetryError.Forbidden
+                return TelemetryError.forbidden
             } else if statusCode() == 413 {
-                return TelemetryError.PayloadTooLarge
+                return TelemetryError.payloadTooLarge
             } else {
-                return TelemetryError.InvalidStatusCode(statusCode: statusCode() ?? 0)
+                return TelemetryError.invalidStatusCode(statusCode: statusCode() ?? 0)
             }
         }
         return nil
@@ -269,22 +269,22 @@ private extension URLResponse {
 // MARK: - Errors
 
 private enum TelemetryError: Error {
-    case Unauthorised
-    case Forbidden
-    case PayloadTooLarge
-    case InvalidStatusCode(statusCode: Int)
+    case unauthorised
+    case forbidden
+    case payloadTooLarge
+    case invalidStatusCode(statusCode: Int)
 }
 
 extension TelemetryError: LocalizedError {
     public var errorDescription: String? {
         switch self {
-        case .InvalidStatusCode(let statusCode):
+        case .invalidStatusCode(let statusCode):
             return "Invalid status code \(statusCode)"
-        case .Unauthorised:
+        case .unauthorised:
             return "Unauthorized (401)"
-        case .Forbidden:
+        case .forbidden:
             return "Forbidden (403)"
-        case .PayloadTooLarge:
+        case .payloadTooLarge:
             return "Payload is too large (413)"
         }
     }

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -10,7 +10,7 @@ import Foundation
     import TVUIKit
 #endif
 
-let TelemetryClientVersion = "SwiftClient 1.5.1"
+let TelemetryClientVersion = "1.5.1"
 
 public typealias TelemetrySignalType = String
 

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -188,7 +188,7 @@ public class TelemetryManager {
         initializedTelemetryManager != nil
     }
 
-    @available(*, deprecated, renamed: "TelemetryDeck.initialize(configuration:)", message: "This call was renamed to `TelemetryDeck.initialize(configuration:)`. Please migrate – a fix-it is available.")
+    @available(*, deprecated, renamed: "TelemetryDeck.initialize(config:)", message: "This call was renamed to `TelemetryDeck.initialize(config:)`. Please migrate – a fix-it is available.")
     public static func initialize(with configuration: TelemetryManagerConfiguration) {
         initializedTelemetryManager = TelemetryManager(configuration: configuration)
     }

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -10,7 +10,7 @@ import Foundation
     import TVUIKit
 #endif
 
-let TelemetryClientVersion = "1.5.1"
+let TelemetryClientVersion = "2.0.0"
 
 /// Configuration for TelemetryManager
 ///

--- a/Sources/TelemetryClient/TelemetryClient.swift
+++ b/Sources/TelemetryClient/TelemetryClient.swift
@@ -10,7 +10,7 @@ import Foundation
     import TVUIKit
 #endif
 
-let TelemetryClientVersion = "2.0.0"
+let telemetryClientVersion = "2.0.0"
 
 /// Configuration for TelemetryManager
 ///
@@ -217,7 +217,10 @@ public class TelemetryManager {
     ///
     /// If you specify a payload, it will be sent in addition to the default payload which includes OS Version, App Version, and more.
     @_disfavoredOverload
-    @available(*, deprecated, message: "This call was renamed to `TelemetryDeck.signal(_:parameters:floatValue:customUserID:)`. Please migrate – no fix-it possible due to the changed order of arguments.")
+    @available(
+        *, deprecated,
+        message: "This call was renamed to `TelemetryDeck.signal(_:parameters:floatValue:customUserID:)`. Please migrate – no fix-it possible due to the changed order of arguments."
+    )
     public static func send(_ signalName: String, for customUserID: String? = nil, floatValue: Double? = nil, with parameters: [String: String] = [:]) {
         TelemetryManager.shared.send(signalName, for: customUserID, floatValue: floatValue, with: parameters)
     }
@@ -277,7 +280,10 @@ public class TelemetryManager {
     /// If you specify a user identifier here, it will take precedence over the default user identifier specified in the `TelemetryManagerConfiguration`.
     ///
     /// If you specify a payload, it will be sent in addition to the default payload which includes OS Version, App Version, and more.
-    @available(*, deprecated, message: "This call was renamed to `TelemetryDeck.signal(_:parameters:floatValue:customUserID:)`. Please migrate – no fix-it possible due to the changed order of arguments.")
+    @available(
+        *, deprecated,
+        message: "This call was renamed to `TelemetryDeck.signal(_:parameters:floatValue:customUserID:)`. Please migrate – no fix-it possible due to the changed order of arguments."
+    )
     public func send(_ signalName: String, with parameters: [String: String] = [:]) {
         send(signalName, for: nil, floatValue: nil, with: parameters)
     }
@@ -288,7 +294,10 @@ public class TelemetryManager {
     ///
     /// If you specify a payload, it will be sent in addition to the default payload which includes OS Version, App Version, and more.
     @_disfavoredOverload
-    @available(*, deprecated, message: "This call was renamed to `TelemetryDeck.signal(_:parameters:floatValue:customUserID:)`. Please migrate – no fix-it possible due to the changed order of arguments.")
+    @available(
+        *, deprecated,
+        message: "This call was renamed to `TelemetryDeck.signal(_:parameters:floatValue:customUserID:)`. Please migrate – no fix-it possible due to the changed order of arguments."
+    )
     public func send(_ signalName: String, for customUserID: String? = nil, floatValue: Double? = nil, with parameters: [String: String] = [:]) {
         // make sure to not send any signals when run by Xcode via SwiftUI previews
         guard !self.configuration.swiftUIPreviewMode, !self.configuration.analyticsDisabled else { return }

--- a/Sources/TelemetryClient/TelemetryDeck.swift
+++ b/Sources/TelemetryClient/TelemetryDeck.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A namespace for TelemetryDeck related functionalities.
 public enum TelemetryDeck {
     /// This alias makes it easier to migrate the configuration type into the TelemetryDeck namespace in future versions when deprecated code is fully removed.
-    public typealias Configuration = TelemetryManagerConfiguration
+    public typealias Config = TelemetryManagerConfiguration
 
     /// Initializes TelemetryDeck with a customizable configuration.
     ///
@@ -11,8 +11,8 @@ public enum TelemetryDeck {
     ///
     /// This function sets up the telemetry system with the specified configuration. It is necessary to call this method before sending any telemetry signals.
     /// For example, you might want to call this in your `init` method of your app's `@main` entry point.
-    public static func initialize(configuration: Configuration) {
-        TelemetryManager.initialize(with: configuration)
+    public static func initialize(config: Config) {
+        TelemetryManager.initialize(with: config)
     }
 
     /// Sends a telemetry signal with optional parameters to TelemetryDeck.

--- a/Sources/TelemetryClient/TelemetryDeck.swift
+++ b/Sources/TelemetryClient/TelemetryDeck.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A namespace for TelemetryDeck related functionalities.
+public enum TelemetryDeck {
+    /// This alias makes it easier to migrate the configuration type into the TelemetryDeck namespace in future versions when deprecated code is fully removed.
+    public typealias Configuration = TelemetryManagerConfiguration
+
+    /// Initializes TelemetryDeck with a customizable configuration.
+    ///
+    /// - Parameter configuration: An instance of `Configuration` which includes all the settings required to configure TelemetryDeck.
+    ///
+    /// This function sets up the telemetry system with the specified configuration. It is necessary to call this method before sending any telemetry signals.
+    /// For example, you might want to call this in your `init` method of your app's `@main` entry point.
+    public static func initialize(configuration: Configuration) {
+        TelemetryManager.initialize(with: configuration)
+    }
+
+    /// Sends a telemetry signal with optional parameters to TelemetryDeck.
+    ///
+    /// - Parameters:
+    ///   - signalName: The name of the signal to be sent. This is a string that identifies the type of event or action being reported.
+    ///   - parameters: A dictionary of additional string key-value pairs that provide further context about the signal. Default is empty.
+    ///   - floatValue: An optional floating-point number that can be used to provide numerical data about the signal. Default is `nil`.
+    ///   - customUserID: An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration. Default is `nil`.
+    ///
+    /// This function wraps the `TelemetryManager.send` method, providing a streamlined way to send signals from anywhere in the app.
+    static func signal(_ signalName: String, parameters: [String: String] = [:], floatValue: Double? = nil, customUserID: String? = nil) {
+        TelemetryManager.send(signalName, for: customUserID, floatValue: floatValue, with: parameters)
+    }
+}

--- a/Sources/TelemetryClient/TelemetryDeck.swift
+++ b/Sources/TelemetryClient/TelemetryDeck.swift
@@ -24,7 +24,7 @@ public enum TelemetryDeck {
     ///   - customUserID: An optional string specifying a custom user identifier. If provided, it will override the default user identifier from the configuration. Default is `nil`.
     ///
     /// This function wraps the `TelemetryManager.send` method, providing a streamlined way to send signals from anywhere in the app.
-    static func signal(_ signalName: String, parameters: [String: String] = [:], floatValue: Double? = nil, customUserID: String? = nil) {
+    public static func signal(_ signalName: String, parameters: [String: String] = [:], floatValue: Double? = nil, customUserID: String? = nil) {
         TelemetryManager.send(signalName, for: customUserID, floatValue: floatValue, with: parameters)
     }
 }

--- a/Sources/TelemetryDeck/Exports.swift
+++ b/Sources/TelemetryDeck/Exports.swift
@@ -1,0 +1,2 @@
+// This file ensures there's a target named `TelemetryDeck` so `import TelemetryDeck` is already possible without renaming `TelemetryClient`.
+@_exported import TelemetryClient

--- a/Sources/TelemetryDeck/PrivacyInfo.xcprivacy
+++ b/Sources/TelemetryDeck/PrivacyInfo.xcprivacy
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeDeviceID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Tests/TelemetryClientTests/CryptoHashingTests.swift
+++ b/Tests/TelemetryClientTests/CryptoHashingTests.swift
@@ -12,7 +12,7 @@ final class CryptoHashingTests: XCTestCase {
 
         let expectedDigestString = "5b8fab7cf45fcece0e99a05950611b7b355917e4fb6daa73fd3d7590764fa53b"
 
-        XCTAssertEqual(expectedDigestString, CryptoHashing.sha256(str: stringToHash, salt: ""))
+        XCTAssertEqual(expectedDigestString, CryptoHashing.sha256(string: stringToHash, salt: ""))
         XCTAssertEqual(expectedDigestString, CryptoHashing.commonCryptoSha256(strData: dataToHash))
 
         // even though we already test if we can import CryptoKit, somehow this still fails on iOS 12,
@@ -31,9 +31,9 @@ final class CryptoHashingTests: XCTestCase {
         let secondSalt = "x21MTSq3MRSmLjVFsYIe"
         let expectedSecondDigestString = "acb027bb031c0f73de26c6b8d0441d9c98449d582a538014c44ca49b4c299aa8"
 
-        XCTAssertEqual(expectedDigestString, CryptoHashing.sha256(str: stringToHash, salt: salt))
-        XCTAssertEqual(expectedSecondDigestString, CryptoHashing.sha256(str: stringToHash, salt: secondSalt))
-        XCTAssertNotEqual(CryptoHashing.sha256(str: stringToHash, salt: salt), CryptoHashing.sha256(str: stringToHash, salt: secondSalt))
+        XCTAssertEqual(expectedDigestString, CryptoHashing.sha256(string: stringToHash, salt: salt))
+        XCTAssertEqual(expectedSecondDigestString, CryptoHashing.sha256(string: stringToHash, salt: secondSalt))
+        XCTAssertNotEqual(CryptoHashing.sha256(string: stringToHash, salt: salt), CryptoHashing.sha256(string: stringToHash, salt: secondSalt))
     }
     #endif
 }

--- a/Tests/TelemetryClientTests/SignalPayloadTests.swift
+++ b/Tests/TelemetryClientTests/SignalPayloadTests.swift
@@ -76,7 +76,7 @@ final class DefaultSignalPayloadTests: XCTestCase {
         #elseif os(Linux)
             expectedResult = "Linux"
         #elseif os(visionOS)
-            expectedResult = "VisionOS"
+            expectedResult = "visionOS"
         #else
             return "Unknown Operating System"
         #endif

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -6,8 +6,8 @@ final class TelemetryClientTests: XCTestCase {
     func testSending() {
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
-        let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
-        TelemetryDeck.initialize(configuration: configuration)
+        let config = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
+        TelemetryDeck.initialize(config: config)
         TelemetryDeck.signal("appOpenedRegularly")
         TelemetryDeck.signal("userLoggedIn", customUserID: "email")
         TelemetryDeck.signal("databaseUpdated", parameters: ["numberOfDatabaseEntries": "3831"])

--- a/Tests/TelemetryClientTests/TelemetryClientTests.swift
+++ b/Tests/TelemetryClientTests/TelemetryClientTests.swift
@@ -7,10 +7,10 @@ final class TelemetryClientTests: XCTestCase {
         let YOUR_APP_ID = "44e0f59a-60a2-4d4a-bf27-1f96ccb4aaa3"
 
         let configuration = TelemetryManagerConfiguration(appID: YOUR_APP_ID)
-        TelemetryManager.initialize(with: configuration)
-        TelemetryManager.send("appOpenedRegularly")
-        TelemetryManager.send("userLoggedIn", for: "email")
-        TelemetryManager.send("databaseUpdated", with: ["numberOfDatabaseEntries": "3831"])
+        TelemetryDeck.initialize(configuration: configuration)
+        TelemetryDeck.signal("appOpenedRegularly")
+        TelemetryDeck.signal("userLoggedIn", customUserID: "email")
+        TelemetryDeck.signal("databaseUpdated", parameters: ["numberOfDatabaseEntries": "3831"])
     }
     
     func testPushAndPop() {
@@ -56,7 +56,7 @@ final class TelemetryClientTests: XCTestCase {
     
     func testSignalEnrichers() throws {
         struct BasicEnricher: SignalEnricher {
-            func enrich(signalType: TelemetrySignalType, for clientUser: String?, floatValue: Double?) -> [String : String] {
+            func enrich(signalType: String, for clientUser: String?, floatValue: Double?) -> [String : String] {
                 ["isTestEnricher": "true"]
             }
         }
@@ -66,8 +66,8 @@ final class TelemetryClientTests: XCTestCase {
         
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
-        TelemetryManager.send("testSignal")
-        
+        TelemetryDeck.signal("testSignal")
+
         let bodyItems = signalManager.processedSignals
         XCTAssertEqual(bodyItems.count, 1)
         let bodyItem = try XCTUnwrap(bodyItems.first)
@@ -76,7 +76,7 @@ final class TelemetryClientTests: XCTestCase {
     
     func testSignalEnrichers_precedence() throws {
         struct BasicEnricher: SignalEnricher {
-            func enrich(signalType: TelemetrySignalType, for clientUser: String?, floatValue: Double?) -> [String : String] {
+            func enrich(signalType: String, for clientUser: String?, floatValue: Double?) -> [String : String] {
                 ["item": "A", "isDebug": "banana"]
             }
         }
@@ -86,8 +86,8 @@ final class TelemetryClientTests: XCTestCase {
         
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
-        TelemetryManager.send("testSignal", with: ["item": "B"])
-        
+        TelemetryDeck.signal("testSignal", parameters: ["item": "B"])
+
         let bodyItems = signalManager.processedSignals
         XCTAssertEqual(bodyItems.count, 1)
         let bodyItem = try XCTUnwrap(bodyItems.first)
@@ -103,7 +103,7 @@ final class TelemetryClientTests: XCTestCase {
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
         
-        TelemetryManager.send("appOpenedRegularly")
+        TelemetryDeck.signal("appOpenedRegularly")
         
         XCTAssertEqual(signalManager.processedSignalTypes.count, 1)
     }
@@ -117,7 +117,7 @@ final class TelemetryClientTests: XCTestCase {
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
         
-        TelemetryManager.send("appOpenedRegularly")
+        TelemetryDeck.signal("appOpenedRegularly")
         
         XCTAssertEqual(signalManager.processedSignalTypes.count, 1)
     }
@@ -131,7 +131,7 @@ final class TelemetryClientTests: XCTestCase {
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
         
-        TelemetryManager.send("appOpenedRegularly")
+        TelemetryDeck.signal("appOpenedRegularly")
         
         XCTAssertTrue(signalManager.processedSignalTypes.isEmpty)
     }
@@ -147,7 +147,7 @@ final class TelemetryClientTests: XCTestCase {
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
         
-        TelemetryManager.send("appOpenedRegularly")
+        TelemetryDeck.signal("appOpenedRegularly")
         
         XCTAssertTrue(signalManager.processedSignalTypes.isEmpty)
         
@@ -162,30 +162,30 @@ final class TelemetryClientTests: XCTestCase {
         let signalManager = FakeSignalManager()
         TelemetryManager.initialize(with: configuration, signalManager: signalManager)
         
-        TelemetryManager.send("appOpenedRegularly", floatValue: 42)
-        
+        TelemetryDeck.signal("appOpenedRegularly", floatValue: 42)
+
         XCTAssertEqual(signalManager.processedSignals.first?.floatValue, 42)
     }
 }
 
 private class FakeSignalManager: SignalManageable {
-    var processedSignalTypes = [TelemetrySignalType]()
+    var processedSignalTypes = [String]()
     var processedSignals = [SignalPostBody]()
     
-    func processSignal(_ signalType: TelemetrySignalType, for clientUser: String?, floatValue: Double?, with additionalPayload: [String : String], configuration: TelemetryManagerConfiguration) {
+    func processSignal(_ signalType: String, parameters: [String : String], floatValue: Double?, customUserID: String?, configuration: TelemetryManagerConfiguration) {
         processedSignalTypes.append(signalType)
         let enrichedMetadata: [String: String] = configuration.metadataEnrichers
-            .map { $0.enrich(signalType: signalType, for: clientUser, floatValue: floatValue) }
+            .map { $0.enrich(signalType: signalType, for: customUserID, floatValue: floatValue) }
             .reduce([String: String](), { $0.applying($1) })
         
-        let payload = DefaultSignalPayload().toDictionary()
+        let payload = DefaultSignalPayload.parameters
             .applying(enrichedMetadata)
-            .applying(additionalPayload)
-        
+            .applying(parameters)
+
         let signalPostBody = SignalPostBody(
             receivedAt: Date(),
             appID: UUID(uuidString: configuration.telemetryAppID)!,
-            clientUser: clientUser ?? "no user",
+            clientUser: customUserID ?? "no user",
             sessionID: configuration.sessionID.uuidString,
             type: "\(signalType)",
             floatValue: floatValue,


### PR DESCRIPTION
This is a follow-up on #149 with the branch renamed to `grand-rename` and the decisions from https://github.com/TelemetryDeck/docs/pull/85 applied. This includes the changes from #149:

> In Swift, Locale.current represents the language and region the app is currently using. When an app is not localized to say German, for example, the identifier will not return de for the language even it's the users preferred language.
> 
> To make it easier for TelemetryDeck users to use a data-driven approach in deciding which languages to localize for next, it is important to add the preferred language of the user though, even if the app doesn't support it. It can also be useful to see just the app language or just the region, without them being clutched together in locale as in en_DE.
> 
> This PR therefore introduces region (the regional part of locale), appLanguage (the language part of locale), and the new preferredLanguage which is the field that is most useful to make the localization expansion decision.

In addition, I have renamed `TelemetryManager.send("A", with: ["a": "b"])` to `TelemetryDeck.signal("A", parameters: ["a": "b"])` as well as `TelemetryManager.initialize` to `TelemetryDeck.initialize` as per https://github.com/TelemetryDeck/docs/pull/85#discussion_r1589092178.